### PR TITLE
Add Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,14 @@ While this repository does not include source code, it is meant as a simple star
 5. Compete for the best record and the league title!
 
 Fantasy football brings fans closer to the action by making every game meaningful and engaging. If you're new to the game, take time to understand player rankings, scoring rules, and strategies for building a winning roster.
+
+## Chrome Extension - Expert Fantasy Football V2
+
+This repository also contains a simple Chrome extension named **Expert Fantasy Football V2**. The extension uses the code in `src/useFPLMe.js` to fetch your Fantasy Premier League data and display it in a popup.
+
+### Installation
+
+1. Open Chrome and navigate to `chrome://extensions`.
+2. Enable **Developer mode** in the top-right corner.
+3. Click **Load unpacked** and select the `extension` folder from this repository.
+4. The extension icon will appear in your browser toolbar. Click it to view your FPL data.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 3,
+  "name": "Expert Fantasy Football V2",
+  "description": "Chrome extension to display Fantasy Premier League data.",
+  "version": "1.0",
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Expert Fantasy Football V2"
+  },
+  "host_permissions": [
+    "https://fantasy.premierleague.com/*"
+  ]
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Expert Fantasy Football V2</title>
+</head>
+<body>
+  <script type="importmap">
+  {
+    "imports": {
+      "react": "https://esm.sh/react@17",
+      "react-dom": "https://esm.sh/react-dom@17"
+    }
+  }
+  </script>
+  <div id="root"></div>
+  <script type="module" src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import useFPLMe from '../src/useFPLMe.js';
+
+function App() {
+  const data = useFPLMe();
+  if (!data) {
+    return React.createElement('div', null, 'Loading...');
+  }
+  return React.createElement('pre', null, JSON.stringify(data, null, 2));
+}
+
+ReactDOM.render(
+  React.createElement(App, null),
+  document.getElementById('root')
+);


### PR DESCRIPTION
## Summary
- add `extension` folder with Chrome manifest and popup
- load React via importmap and display FPL data in popup
- document how to install the new extension

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878fb12d5fc83248ad087f71675964c