### PR TITLE
Add reusable table and player data demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,10 @@ This repository also contains a simple Chrome extension named **Expert Fantasy F
 2. Enable **Developer mode** in the top-right corner.
 3. Click **Load unpacked** and select the `extension` folder from this repository.
 4. The extension icon will appear in your browser toolbar. Click it to view your FPL data.
+
+## Player Data Example
+
+The project includes a reusable table component in `src/Table.js`.
+`src/mockApi.js` generates mock player names and random point totals.
+`src/PlayerData.js` combines these pieces and is rendered by the Chrome
+extension so you can see sample data without accessing a real API.

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,16 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import useFPLMe from '../src/useFPLMe.js';
-
-function App() {
-  const data = useFPLMe();
-  if (!data) {
-    return React.createElement('div', null, 'Loading...');
-  }
-  return React.createElement('pre', null, JSON.stringify(data, null, 2));
-}
+import PlayerData from '../src/PlayerData.js';
 
 ReactDOM.render(
-  React.createElement(App, null),
+  React.createElement(PlayerData, null),
   document.getElementById('root')
 );

--- a/src/PlayerData.js
+++ b/src/PlayerData.js
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+import Table from './Table.js';
+import { fetchPlayerData } from './mockApi.js';
+
+/**
+ * Component that fetches player data from the mocked API and displays it
+ * using the reusable Table component.
+ */
+export default function PlayerData() {
+  const [players, setPlayers] = useState([]);
+
+  useEffect(() => {
+    fetchPlayerData().then(setPlayers);
+  }, []);
+
+  const columns = [
+    { key: 'name', title: 'Player Name' },
+    { key: 'points', title: 'Points' },
+  ];
+
+  if (players.length === 0) {
+    return React.createElement('div', null, 'Loading...');
+  }
+
+  return React.createElement(Table, { columns, data: players });
+}

--- a/src/Table.js
+++ b/src/Table.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+/**
+ * Generic table component that renders rows based on provided column
+ * definitions and data. Columns should be an array of objects with
+ * `key` and `title` properties.
+ */
+export default function Table({ columns, data }) {
+  return React.createElement(
+    'table',
+    { border: 1, cellPadding: 4, cellSpacing: 0 },
+    React.createElement(
+      'thead',
+      null,
+      React.createElement(
+        'tr',
+        null,
+        columns.map((col) =>
+          React.createElement('th', { key: col.key }, col.title)
+        )
+      )
+    ),
+    React.createElement(
+      'tbody',
+      null,
+      data.map((row, rowIndex) =>
+        React.createElement(
+          'tr',
+          { key: rowIndex },
+          columns.map((col) =>
+            React.createElement('td', { key: col.key }, row[col.key])
+          )
+        )
+      )
+    )
+  );
+}

--- a/src/mockApi.js
+++ b/src/mockApi.js
@@ -1,0 +1,14 @@
+/**
+ * Returns a promise that resolves to an array of player objects with a
+ * random points value between 1 and 50. This simulates a network API call.
+ */
+export function fetchPlayerData(count = 10) {
+  return new Promise((resolve) => {
+    const players = Array.from({ length: count }, (_, i) => ({
+      name: `Player ${i + 1}`,
+      points: Math.floor(Math.random() * 50) + 1,
+    }));
+    // Simulate asynchronous call
+    setTimeout(() => resolve(players), 300);
+  });
+}


### PR DESCRIPTION
## Summary
- implement generic `Table` component
- add mocked API with random player points
- create `PlayerData` component using the table and mocked data
- update extension popup to show the new component
- document the example in the README

## Testing
- `node -e "console.log('No tests defined')"`


------
https://chatgpt.com/codex/tasks/task_e_687900471abc832486896338b95dd697